### PR TITLE
Compatibility enhancement with microprofile-config-api 2.0

### DIFF
--- a/imixs-workflow-engine/src/main/java/org/imixs/workflow/engine/ImixsConfigSource.java
+++ b/imixs-workflow-engine/src/main/java/org/imixs/workflow/engine/ImixsConfigSource.java
@@ -31,6 +31,7 @@ package org.imixs.workflow.engine;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.eclipse.microprofile.config.spi.ConfigSource;
@@ -60,6 +61,11 @@ public class ImixsConfigSource implements ConfigSource {
     public static final String NAME = "ImixsConfigSource";
     private Map<String, String> properties = null;
     private static Logger logger = Logger.getLogger(ImixsConfigSource.class.getName());
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return getProperties().keySet();
+    }
 
     @Override
     public int getOrdinal() {


### PR DESCRIPTION
artefiact imixs-workflow-engine contains class org.imixs.workflow.engine.ImixsConfigSource, that implements org.eclipse.microprofile.config.spi.ConfigSource from microprofile-config-api. In version 1.4 interface [ConfigSource](https://github.com/eclipse/microprofile-config/blob/1.4/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigSource.java) contains default implementation for method getPropertyNames(). But in version 2.0 of [ConfigSource](https://github.com/eclipse/microprofile-config/blob/2.0/api/src/main/java/org/eclipse/microprofile/config/spi/ConfigSource.java) this implementation is absent. For this reason we have an error 
<details><summary>java.lang.AbstractMethodError: Receiver class org.imixs.workflow.engine.ImixsConfigSource does not define or inherit an implementation of the resolved method abstract getPropertyNames()Ljava/util/Set; of interface org.eclipse.microprofile.config.spi.ConfigSource with stacktrace (from wildfly-23.0.2)</summary>
ERROR [org.jboss.msc.service.fail] (MSC service thread 1-6) MSC000001: Failed to start service jboss.deployment.unit."imixs-jsf-example.war".WeldStartService: org.jboss.msc.service.StartException in service jboss.deployment.unit."imixs-jsf-example.war".WeldStartService: Failed to start service
	at org.jboss.msc@1.4.12.Final//org.jboss.msc.service.ServiceControllerImpl$StartTask.execute(ServiceControllerImpl.java:1731)
	at org.jboss.msc@1.4.12.Final//org.jboss.msc.service.ServiceControllerImpl$ControllerTask.run(ServiceControllerImpl.java:1559)
	at org.jboss.threads@2.4.0.Final//org.jboss.threads.ContextClassLoaderSavingRunnable.run(ContextClassLoaderSavingRunnable.java:35)
	at org.jboss.threads@2.4.0.Final//org.jboss.threads.EnhancedQueueExecutor.safeRun(EnhancedQueueExecutor.java:1990)
	at org.jboss.threads@2.4.0.Final//org.jboss.threads.EnhancedQueueExecutor$ThreadBody.doRunTask(EnhancedQueueExecutor.java:1486)
	at org.jboss.threads@2.4.0.Final//org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1363)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: org.jboss.weld.exceptions.DeploymentException
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.bootstrap.events.AbstractDeploymentContainerEvent.fire(AbstractDeploymentContainerEvent.java:38)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.bootstrap.events.AfterDeploymentValidationImpl.fire(AfterDeploymentValidationImpl.java:28)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.bootstrap.WeldStartup.validateBeans(WeldStartup.java:505)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.bootstrap.WeldBootstrap.validateBeans(WeldBootstrap.java:93)
	at org.jboss.as.weld@23.0.2.Final//org.jboss.as.weld.WeldStartService.start(WeldStartService.java:98)
	at org.jboss.msc@1.4.12.Final//org.jboss.msc.service.ServiceControllerImpl$StartTask.startService(ServiceControllerImpl.java:1739)
	at org.jboss.msc@1.4.12.Final//org.jboss.msc.service.ServiceControllerImpl$StartTask.execute(ServiceControllerImpl.java:1701)
	... 6 more
Caused by: javax.enterprise.event.ObserverException
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at java.base/java.lang.Class.newInstance(Class.java:584)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.security.NewInstanceAction.run(NewInstanceAction.java:33)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.injection.Exceptions.rethrowException(Exceptions.java:40)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.injection.Exceptions.rethrowException(Exceptions.java:78)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.injection.StaticMethodInjectionPoint.invoke(StaticMethodInjectionPoint.java:103)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.injection.StaticMethodInjectionPoint.invoke(StaticMethodInjectionPoint.java:85)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.injection.MethodInvocationStrategy$SimpleMethodInvocationStrategy.invoke(MethodInvocationStrategy.java:168)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.event.ObserverMethodImpl.sendEvent(ObserverMethodImpl.java:330)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.event.ExtensionObserverMethodImpl.sendEvent(ExtensionObserverMethodImpl.java:123)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.event.ObserverMethodImpl.sendEvent(ObserverMethodImpl.java:308)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.event.ObserverMethodImpl.notify(ObserverMethodImpl.java:286)
	at javax.enterprise.api//javax.enterprise.inject.spi.ObserverMethod.notify(ObserverMethod.java:124)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.util.Observers.notify(Observers.java:166)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.event.ObserverNotifier.notifySyncObservers(ObserverNotifier.java:285)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.event.ObserverNotifier.notify(ObserverNotifier.java:273)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.event.ObserverNotifier.fireEvent(ObserverNotifier.java:177)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.event.ObserverNotifier.fireEvent(ObserverNotifier.java:171)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.bootstrap.events.AbstractContainerEvent.fire(AbstractContainerEvent.java:53)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.bootstrap.events.AbstractDeploymentContainerEvent.fire(AbstractDeploymentContainerEvent.java:35)
	... 12 more
Caused by: java.lang.AbstractMethodError: Receiver class org.imixs.workflow.engine.ImixsConfigSource does not define or inherit an implementation of the resolved method abstract getPropertyNames()Ljava/util/Set; of interface org.eclipse.microprofile.config.spi.ConfigSource.
	at io.smallrye.config//io.smallrye.config.ConfigValueConfigSourceWrapper.getPropertyNames(ConfigValueConfigSourceWrapper.java:53)
	at io.smallrye.config//io.smallrye.config.SmallRyeConfigSourceInterceptor.iterateNames(SmallRyeConfigSourceInterceptor.java:37)
	at io.smallrye.config//io.smallrye.config.SmallRyeConfigSourceInterceptorContext.iterateNames(SmallRyeConfigSourceInterceptorContext.java:25)
	at io.smallrye.config//io.smallrye.config.ConfigSourceInterceptor.iterateNames(ConfigSourceInterceptor.java:58)
	at io.smallrye.config//io.smallrye.config.SmallRyeConfigSourceInterceptorContext.iterateNames(SmallRyeConfigSourceInterceptorContext.java:25)
	at io.smallrye.config//io.smallrye.config.ConfigSourceInterceptor.iterateNames(ConfigSourceInterceptor.java:58)
	at io.smallrye.config//io.smallrye.config.SmallRyeConfigSourceInterceptorContext.iterateNames(SmallRyeConfigSourceInterceptorContext.java:25)
	at io.smallrye.config//io.smallrye.config.ProfileConfigSourceInterceptor.iterateNames(ProfileConfigSourceInterceptor.java:96)
	at io.smallrye.config//io.smallrye.config.SmallRyeConfigSourceInterceptorContext.iterateNames(SmallRyeConfigSourceInterceptorContext.java:25)
	at io.smallrye.config//io.smallrye.config.ConfigSourceInterceptor.iterateNames(ConfigSourceInterceptor.java:58)
	at io.smallrye.config//io.smallrye.config.SmallRyeConfigSourceInterceptorContext.iterateNames(SmallRyeConfigSourceInterceptorContext.java:25)
	at io.smallrye.config//io.smallrye.config.SmallRyeConfig.getPropertyNames(SmallRyeConfig.java:224)
	at io.smallrye.config//io.smallrye.config.inject.ConfigExtension.validate(ConfigExtension.java:129)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.jboss.weld.core@3.1.6.Final//org.jboss.weld.injection.StaticMethodInjectionPoint.invoke(StaticMethodInjectionPoint.java:95)
	... 26 more
</details>

Change from this commit solved this problem. Also, it compatible with previous realizations: I only moved default interface implementation to implementing class.